### PR TITLE
Check for semaphore max value.

### DIFF
--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <assert.h>
 #include "../semaphores.h"
 
 semaphore_t *os_semaphore_create(int count)
@@ -7,6 +8,7 @@ semaphore_t *os_semaphore_create(int count)
     sem = malloc(sizeof(semaphore_t));
 
     sem->count = count;
+    sem->max_count = count;
     sem->acquired_count = 0;
 
     return sem;
@@ -26,4 +28,5 @@ void os_semaphore_take(semaphore_t *sem)
 void os_semaphore_release(semaphore_t *sem)
 {
     sem->count ++;
+    assert(sem->count <= sem->max_count);
 }

--- a/mock/semaphores.h
+++ b/mock/semaphores.h
@@ -6,6 +6,7 @@
 typedef struct {
     int count;
     int acquired_count;
+    int max_count;
 } semaphore_t;
 
 #endif

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -19,6 +19,7 @@ TEST(SemaphoreMockTestGroup, CanCreateSemaphoreWithCount)
 {
     sem = os_semaphore_create(1);
     CHECK_EQUAL(1, sem->count);
+    CHECK_EQUAL(1, sem->max_count);
 }
 
 TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
@@ -33,7 +34,8 @@ TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
 TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
 {
     sem = os_semaphore_create(1);
+    os_semaphore_take(sem);
     os_semaphore_release(sem);
 
-    CHECK_EQUAL(2, sem->count);
+    CHECK_EQUAL(1, sem->count);
 }


### PR DESCRIPTION
As discussed in issue #2, we want to fail hard if we release a semaphore more than its initial value.
