### PR TITLE
Assserts that the semaphore is available.

### DIFF
--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -21,6 +21,7 @@ void os_semaphore_delete(semaphore_t *sem)
 
 void os_semaphore_take(semaphore_t *sem)
 {
+    assert(sem->count > 0);
     sem->count--;
     sem->acquired_count++;
 }


### PR DESCRIPTION
As discussed in issue #1, the tests should fail when we try to take a semaphore with a count of zero, since all unit tests run single threaded.
