### PR TITLE
Added clang to continuous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: cpp
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 compiler:
   - gcc
+  - clang
 
 before_install:
     - git clone https://github.com/cpputest/cpputest ../cpputest


### PR DESCRIPTION
I added Clang support to the Travis CI build, I think it is good to have the code tested by two different compilers, it prevents bugs.
