### PR TITLE
Fix issue #6 (semaphore max_count).

### DIFF
--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -8,7 +8,6 @@ semaphore_t *os_semaphore_create(int count)
     sem = malloc(sizeof(semaphore_t));
 
     sem->count = count;
-    sem->max_count = count;
     sem->acquired_count = 0;
 
     return sem;
@@ -29,5 +28,4 @@ void os_semaphore_take(semaphore_t *sem)
 void os_semaphore_release(semaphore_t *sem)
 {
     sem->count ++;
-    assert(sem->count <= sem->max_count);
 }

--- a/mock/semaphores.h
+++ b/mock/semaphores.h
@@ -6,7 +6,6 @@
 typedef struct {
     int count;
     int acquired_count;
-    int max_count;
 } semaphore_t;
 
 #endif

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -20,7 +20,6 @@ TEST(SemaphoreMockTestGroup, CanCreateSemaphoreWithCount)
 {
     sem = os_semaphore_create(1);
     CHECK_EQUAL(1, sem->count);
-    CHECK_EQUAL(1, sem->max_count);
 }
 
 TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
@@ -35,10 +34,9 @@ TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
 TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
 {
     sem = os_semaphore_create(1);
-    os_semaphore_take(sem);
     os_semaphore_release(sem);
 
-    CHECK_EQUAL(1, sem->count);
+    CHECK_EQUAL(2, sem->count);
 }
 
 


### PR DESCRIPTION
This PR fixes issue #6 . I removed the assertion about releasing a semaphore more than it's initial value and changed a test to reflect this behaviour.
