### PR TITLE
Fix issue #11 (non-blocking pend / with timeout)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,7 +77,7 @@ if (os_mutex_try(my_mutex)) {
 if (os_mutex_try_timeout(my_mutex, 69.0)) {
     // The resource is mine.
 } else {
-    // Waitet 69 ms for the resource. It wasn't enough.
+    // Waited 69 ms for the resource. It wasn't enough.
 }
 
 /* Release mutex */

--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ if (os_semaphore_try(mysem)) {
 }
 
 /* Block until available or timeout [ms]. */
-if (os_semaphore_try_timeout(mysem, 42.0)) {
+if (os_semaphore_try_timeout(mysem, 42000)) {
     // Decreased semaphore
 } else {
     // Semaphore not greater than zero after 42 ms of waiting
@@ -74,7 +74,7 @@ if (os_mutex_try(my_mutex)) {
 }
 
 /* Acquire mutex blocking with timeout */
-if (os_mutex_try_timeout(my_mutex, 69.0)) {
+if (os_mutex_try_timeout(my_mutex, 69000)) {
     // The resource is mine.
 } else {
     // Waited 69 ms for the resource. It wasn't enough.

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,18 @@ mysem = os_semaphore_create(10);
 /* Take (decrease) semaphore, blocks until available.*/
 os_semaphore_take(mysem);
 
+/* Only take semaphore when immediately available. */
+if (os_semaphore_try(mysem)) {
+    // Decreased semaphore
+}
+
+/* Block until available or timeout [ms]. */
+if (os_semaphore_try_timeout(mysem, 42.0)) {
+    // Decreased semaphore
+} else {
+    // Semaphore not greater than zero after 42 ms of waiting
+}
+
 /* Release (increase) semaphore. */
 os_semaphore_release(mysem);
 
@@ -55,6 +67,18 @@ my_mutex = os_mutex_create();
 
 /* Acquire mutex */
 os_mutex_take(my_mutex);
+
+/* Acquire mutex non-blocking */
+if (os_mutex_try(my_mutex)) {
+    // The resource is mine.
+}
+
+/* Acquire mutex blocking with timeout */
+if (os_mutex_try_timeout(my_mutex, 69.0)) {
+    // The resource is mine.
+} else {
+    // Waitet 69 ms for the resource. It wasn't enough.
+}
 
 /* Release mutex */
 os_mutex_release(my_mutex);

--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ if (os_semaphore_try(mysem)) {
     // Decreased semaphore
 }
 
-/* Block until available or timeout [ms]. */
+/* Block until available or timeout. */
 if (os_semaphore_try_timeout(mysem, 42000)) {
     // Decreased semaphore
 } else {

--- a/mock/mutex.c
+++ b/mock/mutex.c
@@ -24,6 +24,17 @@ void os_mutex_take(mutex_t *mutex)
     mutex->acquired_count++;
 }
 
+bool os_mutex_try(mutex_t *mutex)
+{
+    if(mutex->acquired) {
+        return false;
+    } else {
+        mutex->acquired = true;
+        mutex->acquired_count++;
+        return true;
+    }
+}
+
 void os_mutex_release(mutex_t *mutex)
 {
     assert(mutex->acquired == true);

--- a/mock/mutex.c
+++ b/mock/mutex.c
@@ -35,7 +35,7 @@ bool os_mutex_try(mutex_t *mutex)
     }
 }
 
-bool os_mutex_try_timeout(mutex_t *mutex, float timeout)
+bool os_mutex_try_timeout(mutex_t *mutex, uint32_t timeout)
 {
     assert(timeout >= 0);
     return os_mutex_try(mutex);

--- a/mock/mutex.c
+++ b/mock/mutex.c
@@ -35,6 +35,15 @@ bool os_mutex_try(mutex_t *mutex)
     }
 }
 
+bool os_mutex_try_timeout(mutex_t *mutex, float timeout)
+{
+    /* Single-threaded test, so try_timeout == try
+     * In the real thing, timeout should be checked like this:
+     * if (timeout < 0) timeout = 0;
+     */
+    return os_mutex_try(mutex);
+}
+
 void os_mutex_release(mutex_t *mutex)
 {
     assert(mutex->acquired == true);

--- a/mock/mutex.c
+++ b/mock/mutex.c
@@ -37,10 +37,7 @@ bool os_mutex_try(mutex_t *mutex)
 
 bool os_mutex_try_timeout(mutex_t *mutex, float timeout)
 {
-    /* Single-threaded test, so try_timeout == try
-     * In the real thing, timeout should be checked like this:
-     * if (timeout < 0) timeout = 0;
-     */
+    assert(timeout >= 0);
     return os_mutex_try(mutex);
 }
 

--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -35,7 +35,7 @@ bool os_semaphore_try(semaphore_t *sem){
     }
 }
 
-bool os_semaphore_try_timeout(semaphore_t *sem, float timeout)
+bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout)
 {
     assert(timeout >= 0);
     return os_semaphore_try(sem);

--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -25,6 +25,16 @@ void os_semaphore_take(semaphore_t *sem)
     sem->acquired_count++;
 }
 
+bool os_semaphore_try(semaphore_t *sem){
+    if (sem->count < 1) {
+        return false;
+    } else {
+        sem->count--;
+        sem->acquired_count++;
+        return true;
+    }
+}
+
 void os_semaphore_release(semaphore_t *sem)
 {
     sem->count ++;

--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -37,10 +37,7 @@ bool os_semaphore_try(semaphore_t *sem){
 
 bool os_semaphore_try_timeout(semaphore_t *sem, float timeout)
 {
-    /* Single-threaded test, so try_timeout == try
-     * In the real thing, timeout should be checked like this:
-     * if (timeout < 0) timeout = 0;
-     */
+    assert(timeout >= 0);
     return os_semaphore_try(sem);
 }
 

--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -35,6 +35,15 @@ bool os_semaphore_try(semaphore_t *sem){
     }
 }
 
+bool os_semaphore_try_timeout(semaphore_t *sem, float timeout)
+{
+    /* Single-threaded test, so try_timeout == try
+     * In the real thing, timeout should be checked like this:
+     * if (timeout < 0) timeout = 0;
+     */
+    return os_semaphore_try(sem);
+}
+
 void os_semaphore_release(semaphore_t *sem)
 {
     sem->count ++;

--- a/mutex.h
+++ b/mutex.h
@@ -1,6 +1,8 @@
 #ifndef MUTEX_H_
 #define MUTEX_H_
 
+#include <stdbool.h>
+
 #ifdef __unix__
 #include "mock/mutex.h"
 #endif
@@ -13,6 +15,9 @@ void os_mutex_delete(mutex_t *mutex);
 
 /** Doesn't return until the mutex is acquired. */
 void os_mutex_take(mutex_t *mutex);
+
+/** Acquire the mutex non-blocking */
+bool os_mutex_try(mutex_t *mutex);
 
 /** Release a mutex. */
 void os_mutex_release(mutex_t *mutex);

--- a/mutex.h
+++ b/mutex.h
@@ -19,6 +19,9 @@ void os_mutex_take(mutex_t *mutex);
 /** Acquire the mutex non-blocking */
 bool os_mutex_try(mutex_t *mutex);
 
+/** Acquire the mutex blocking with timeout [ms] */
+bool os_mutex_try_timeout(mutex_t *mutex, float timeout);
+
 /** Release a mutex. */
 void os_mutex_release(mutex_t *mutex);
 

--- a/mutex.h
+++ b/mutex.h
@@ -2,6 +2,7 @@
 #define MUTEX_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __unix__
 #include "mock/mutex.h"
@@ -19,8 +20,8 @@ void os_mutex_take(mutex_t *mutex);
 /** Acquire the mutex non-blocking */
 bool os_mutex_try(mutex_t *mutex);
 
-/** Acquire the mutex blocking with timeout [ms] */
-bool os_mutex_try_timeout(mutex_t *mutex, float timeout);
+/** Acquire the mutex blocking with timeout [us] */
+bool os_mutex_try_timeout(mutex_t *mutex, uint32_t timeout);
 
 /** Release a mutex. */
 void os_mutex_release(mutex_t *mutex);

--- a/semaphores.h
+++ b/semaphores.h
@@ -20,7 +20,7 @@ void os_semaphore_take(semaphore_t *sem);
 bool os_semaphore_try(semaphore_t *sem);
 
 /** Acquire the semaphore blocking with timeout [ms] */
-bool os_semaphore_try_timeout(semaphore_t *semaphore, float timeout);
+bool os_semaphore_try_timeout(semaphore_t *sem, float timeout);
 
 /** Releases (posts) a semaphore. */
 void os_semaphore_release(semaphore_t *sem);

--- a/semaphores.h
+++ b/semaphores.h
@@ -1,6 +1,8 @@
 #ifndef SEMAPHORE_H_
 #define SEMAPHORE_H_
 
+#include <stdbool.h>
+
 #ifdef __unix__
 #include "mock/semaphores.h"
 #endif
@@ -13,6 +15,9 @@ void os_semaphore_delete(semaphore_t *sem);
 
 /** Takes a semaphore if available, blocks if not available. */
 void os_semaphore_take(semaphore_t *sem);
+
+/** Takes a semaphore non-blocking */
+bool os_semaphore_try(semaphore_t *sem);
 
 /** Releases (posts) a semaphore. */
 void os_semaphore_release(semaphore_t *sem);

--- a/semaphores.h
+++ b/semaphores.h
@@ -2,6 +2,7 @@
 #define SEMAPHORE_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __unix__
 #include "mock/semaphores.h"
@@ -19,8 +20,8 @@ void os_semaphore_take(semaphore_t *sem);
 /** Takes a semaphore non-blocking */
 bool os_semaphore_try(semaphore_t *sem);
 
-/** Acquire the semaphore blocking with timeout [ms] */
-bool os_semaphore_try_timeout(semaphore_t *sem, float timeout);
+/** Acquire the semaphore blocking with timeout [us] */
+bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout);
 
 /** Releases (posts) a semaphore. */
 void os_semaphore_release(semaphore_t *sem);

--- a/semaphores.h
+++ b/semaphores.h
@@ -19,6 +19,9 @@ void os_semaphore_take(semaphore_t *sem);
 /** Takes a semaphore non-blocking */
 bool os_semaphore_try(semaphore_t *sem);
 
+/** Acquire the semaphore blocking with timeout [ms] */
+bool os_semaphore_try_timeout(semaphore_t *semaphore, float timeout);
+
 /** Releases (posts) a semaphore. */
 void os_semaphore_release(semaphore_t *sem);
 

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -42,6 +42,31 @@ TEST(SemaphoreMockTestGroup, CanTrySemaphore)
     CHECK_EQUAL(1, sem->acquired_count);
 }
 
+TEST(SemaphoreMockTestGroup, CanTryTimeoutSemaphore)
+{
+    sem = os_semaphore_create(1);
+
+    CHECK_TRUE(os_semaphore_try_timeout(sem, 42.0));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_FALSE(os_semaphore_try_timeout(sem, 69.0));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_EQUAL(1, sem->acquired_count);
+}
+
+TEST(SemaphoreMockTestGroup, CanHandleNegativeTryTimeout)
+{
+    /* Negative values should be considered as a timeout of zero,
+     * i.e. os_semaphore_try()
+     */
+    sem = os_semaphore_create(1);
+
+    CHECK_TRUE(os_semaphore_try_timeout(sem, -42.0));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_FALSE(os_semaphore_try_timeout(sem, -69.0));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_EQUAL(1, sem->acquired_count);
+}
+
 TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
 {
     sem = os_semaphore_create(1);
@@ -84,6 +109,25 @@ TEST(MutexMockTestGroup, CanTryMutex)
     CHECK_TRUE(os_mutex_try(mutex));
     CHECK_TRUE(mutex->acquired);
     CHECK_FALSE(os_mutex_try(mutex));
+    CHECK_EQUAL(1, mutex->acquired_count);
+}
+
+TEST(MutexMockTestGroup, CanTryTimeoutMutex)
+{
+    CHECK_TRUE(os_mutex_try_timeout(mutex, 42.0));
+    CHECK_TRUE(mutex->acquired);
+    CHECK_FALSE(os_mutex_try_timeout(mutex, 69.0));
+    CHECK_EQUAL(1, mutex->acquired_count);
+}
+
+TEST(MutexMockTestGroup, CanHandleNegativeTryTimeout)
+{
+    /* Negative values should be considered as a timeout of zero,
+     * i.e. os_mutex_try()
+     */
+    CHECK_TRUE(os_mutex_try_timeout(mutex, -42.0));
+    CHECK_TRUE(mutex->acquired);
+    CHECK_FALSE(os_mutex_try_timeout(mutex, -69.0));
     CHECK_EQUAL(1, mutex->acquired_count);
 }
 

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -68,6 +68,13 @@ TEST(MutexMockTestGroup, CanTakeMutex)
     CHECK_EQUAL(1, mutex->acquired_count);
 }
 
+TEST(MutexMockTestGroup, CanTryMutex)
+{
+    CHECK_TRUE(os_mutex_try(mutex));
+    CHECK_FALSE(os_mutex_try(mutex));
+    CHECK_EQUAL(1, mutex->acquired_count);
+}
+
 TEST(MutexMockTestGroup, CanReleaseMutex)
 {
     os_mutex_take(mutex);

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -53,20 +53,6 @@ TEST(SemaphoreMockTestGroup, CanTryTimeoutSemaphore)
     CHECK_EQUAL(1, sem->acquired_count);
 }
 
-TEST(SemaphoreMockTestGroup, CanHandleNegativeTryTimeout)
-{
-    /* Negative values should be considered as a timeout of zero,
-     * i.e. os_semaphore_try()
-     */
-    sem = os_semaphore_create(1);
-
-    CHECK_TRUE(os_semaphore_try_timeout(sem, -42.0));
-    CHECK_EQUAL(0, sem->count);
-    CHECK_FALSE(os_semaphore_try_timeout(sem, -69.0));
-    CHECK_EQUAL(0, sem->count);
-    CHECK_EQUAL(1, sem->acquired_count);
-}
-
 TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
 {
     sem = os_semaphore_create(1);
@@ -117,17 +103,6 @@ TEST(MutexMockTestGroup, CanTryTimeoutMutex)
     CHECK_TRUE(os_mutex_try_timeout(mutex, 42.0));
     CHECK_TRUE(mutex->acquired);
     CHECK_FALSE(os_mutex_try_timeout(mutex, 69.0));
-    CHECK_EQUAL(1, mutex->acquired_count);
-}
-
-TEST(MutexMockTestGroup, CanHandleNegativeTryTimeout)
-{
-    /* Negative values should be considered as a timeout of zero,
-     * i.e. os_mutex_try()
-     */
-    CHECK_TRUE(os_mutex_try_timeout(mutex, -42.0));
-    CHECK_TRUE(mutex->acquired);
-    CHECK_FALSE(os_mutex_try_timeout(mutex, -69.0));
     CHECK_EQUAL(1, mutex->acquired_count);
 }
 

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -46,9 +46,9 @@ TEST(SemaphoreMockTestGroup, CanTryTimeoutSemaphore)
 {
     sem = os_semaphore_create(1);
 
-    CHECK_TRUE(os_semaphore_try_timeout(sem, 42.0));
+    CHECK_TRUE(os_semaphore_try_timeout(sem, 42000));
     CHECK_EQUAL(0, sem->count);
-    CHECK_FALSE(os_semaphore_try_timeout(sem, 69.0));
+    CHECK_FALSE(os_semaphore_try_timeout(sem, 69000));
     CHECK_EQUAL(0, sem->count);
     CHECK_EQUAL(1, sem->acquired_count);
 }
@@ -100,9 +100,9 @@ TEST(MutexMockTestGroup, CanTryMutex)
 
 TEST(MutexMockTestGroup, CanTryTimeoutMutex)
 {
-    CHECK_TRUE(os_mutex_try_timeout(mutex, 42.0));
+    CHECK_TRUE(os_mutex_try_timeout(mutex, 42000));
     CHECK_TRUE(mutex->acquired);
-    CHECK_FALSE(os_mutex_try_timeout(mutex, 69.0));
+    CHECK_FALSE(os_mutex_try_timeout(mutex, 69000));
     CHECK_EQUAL(1, mutex->acquired_count);
 }
 

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -82,6 +82,7 @@ TEST(MutexMockTestGroup, CanTakeMutex)
 TEST(MutexMockTestGroup, CanTryMutex)
 {
     CHECK_TRUE(os_mutex_try(mutex));
+    CHECK_TRUE(mutex->acquired);
     CHECK_FALSE(os_mutex_try(mutex));
     CHECK_EQUAL(1, mutex->acquired_count);
 }

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -31,6 +31,17 @@ TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
     CHECK_EQUAL(1, sem->acquired_count);
 }
 
+TEST(SemaphoreMockTestGroup, CanTrySemaphore)
+{
+    sem = os_semaphore_create(1);
+
+    CHECK_TRUE(os_semaphore_try(sem));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_FALSE(os_semaphore_try(sem));
+    CHECK_EQUAL(0, sem->count);
+    CHECK_EQUAL(1, sem->acquired_count);
+}
+
 TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
 {
     sem = os_semaphore_create(1);


### PR DESCRIPTION
I chose `float` milliseconds for the timeout as it seems to be the most readable.
