### PR TITLE
Critical section macros

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,3 +100,67 @@ do_atomic_stuff(my_mutex);
 CHECK_FALSE(my_mutex->acquired);
 ```
 
+# Critical Section
+A critical section disables temporarily all interrupts at the CPU level, ensuring that all variables and data structures are edited atomically.
+
+
+## Direct Example 
+
+```c
+void myFunction(void* mySharedResource) {
+
+    /* initialize variables */
+    int myVariable = 0; 
+
+    /* after ALL initialization, call this */
+    CRITICAL_SECTION_ALLOC();
+
+    /* ... do whatever stuff you need ... */
+
+    /* enter critical section */
+    CRITICAL_SECTION_ENTER();
+
+    // The resource is mine.
+
+    /* exit critical section */
+    CRITICAL_SECTION_EXIT();
+}
+```
+
+## Block Example 
+
+```c
+void myFunction(void* mySharedResource) {
+
+    /* initialize variables */
+    int myVariable = 0; 
+
+    /* after ALL initialization, call this */
+    CRITICAL_SECTION_ALLOC();
+
+    /* ... do whatever stuff you need ... */
+
+    /* enter critical section */
+    CRITICAL_SECTION() {
+        // The resource is mine.
+    }
+}
+```
+
+## Use in testing
+When using the mock implementation, critical section is represented through a single variable.
+`__mock_critical_depth` contains the number of nested critical sections currently active.
+To access this value, two function-like macros are available.
+
+1. `mock_critsec_is_critical()` returns a bool, indicating whether the calling code is currently in a critical section
+2. `mock_critsec_get_depth()` returns an `int16_t` indicating the nesting depth of the critical sections
+
+This allows tests to check that a critical section finishes correctly :
+```c
+CRITICAL_SECTION_ALLOC();
+CRIICAL_SECTION() { 
+    do_atomic_stuff();
+}
+CHECK_FALSE(mock_critsec_is_critical());
+```
+

--- a/criticalsection.h
+++ b/criticalsection.h
@@ -5,9 +5,7 @@
 #include <stdint.h>
 
 #ifdef __unix__
-#define CPU_CRITICAL_ENTER()
-#define CPU_CRITICAL_EXIT()
-#define CPU_SR_ALLOC()
+#include "mock/criticalsection.h"
 #else
 #include <cpu.h>
 #endif
@@ -38,26 +36,5 @@
  * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
  */
 #define CRITICAL_SECTION_EXIT() {if(sizeof(__critical_alloc)>0){CPU_CRITICAL_EXIT();}}
-
-int main(int argc, char** argv)
-{
-    uint16_t roll = 20;
-
-    CRITICAL_SECTION_ALLOC();
-
-    printf("Isn't critical... yet! \n");
-
-    CRITICAL_SECTION_ENTER() 
-        printf("Rolled a %d.. Critical printf ! \n",roll);
-    CRITICAL_SECTION_EXIT()
-
-    printf("Isn't critical... anymore! \n");
-
-    CRITICAL_SECTION() {
-        printf("Rolled a %d.. Critical printf again ! \n",roll);
-    }
-    
-    return 0;
-}
     
 #endif

--- a/criticalsection.h
+++ b/criticalsection.h
@@ -23,7 +23,7 @@
                                                     if(__critctrl < 0) \
         {    CPU_CRITICAL_ENTER(); } \
         else if(__critctrl > 0) \
-        {   CPU_CRITICAL_EXIT(); break; }\
+        {   CPU_CRITICAL_EXIT(); __critctrl = 0; break; }\
         else for(__critical_alloc = 0; __critical_alloc<1; __critical_alloc++) 
   
 

--- a/criticalsection.h
+++ b/criticalsection.h
@@ -1,0 +1,31 @@
+﻿#ifndef CRITICALSECTION_H_
+#define CRITICALSECTION_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#ifdef __unix__
+#define CPU_CRITICAL_ENTER()
+#define CPU_CRITICAL_EXIT()
+#define CPU_SR_ALLOC()
+#else
+#include <cpu.h>
+#endif
+
+/** Takes care of necessary allocs for critical section
+ *  \warning Call after all variable initializations and before all functions
+ */
+#define CRITICAL_SECTION_ALLOC() int16_t __critctrl; int16_t __critsection; CPU_SR_ALLOC();
+
+/** Critical section macro
+ * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
+ */
+#define CRITICAL_SECTION() assert(sizeof(__critctrl)>0); for(__critctrl = -1; __critctrl < 2; __critctrl++) \
+    if(__critctrl < 0) \
+    { CPU_CRITICAL_ENTER(); } \
+    else if(__critctrl > 0) \
+    { CPU_CRITICAL_EXIT(); break; }\
+    else for(__critsection = 0; __critsection<1; __critsection++) 
+    
+#endif

--- a/criticalsection.h
+++ b/criticalsection.h
@@ -3,7 +3,6 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <assert.h>
 
 #ifdef __unix__
 #define CPU_CRITICAL_ENTER()
@@ -13,19 +12,52 @@
 #include <cpu.h>
 #endif
 
+
 /** Takes care of necessary allocs for critical section
  *  \warning Call after all variable initializations and before all functions
  */
-#define CRITICAL_SECTION_ALLOC() int16_t __critctrl; int16_t __critsection; CPU_SR_ALLOC();
+#define CRITICAL_SECTION_ALLOC() int16_t __critctrl; int16_t __critical_alloc; CPU_SR_ALLOC();
 
 /** Critical section macro
  * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
  */
-#define CRITICAL_SECTION() assert(sizeof(__critctrl)>0); for(__critctrl = -1; __critctrl < 2; __critctrl++) \
-    if(__critctrl < 0) \
-    { CPU_CRITICAL_ENTER(); } \
-    else if(__critctrl > 0) \
-    { CPU_CRITICAL_EXIT(); break; }\
-    else for(__critsection = 0; __critsection<1; __critsection++) 
+#define CRITICAL_SECTION() for(__critctrl = -1; __critctrl < 2 && sizeof(__critical_alloc)>0; __critctrl++) \
+                                                    if(__critctrl < 0) \
+        {    CPU_CRITICAL_ENTER(); } \
+        else if(__critctrl > 0) \
+        {   CPU_CRITICAL_EXIT(); break; }\
+        else for(__critical_alloc = 0; __critical_alloc<1; __critical_alloc++) 
+  
+
+/** Critical section enter macro
+ * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
+ */
+#define CRITICAL_SECTION_ENTER() {if(sizeof(__critical_alloc)>0){CPU_CRITICAL_ENTER();}}
+
+/** Critical section exit macro
+ * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
+ */
+#define CRITICAL_SECTION_EXIT() {if(sizeof(__critical_alloc)>0){CPU_CRITICAL_EXIT();}}
+
+int main(int argc, char** argv)
+{
+    uint16_t roll = 20;
+
+    CRITICAL_SECTION_ALLOC();
+
+    printf("Isn't critical... yet! \n");
+
+    CRITICAL_SECTION_ENTER() 
+        printf("Rolled a %d.. Critical printf ! \n",roll);
+    CRITICAL_SECTION_EXIT()
+
+    printf("Isn't critical... anymore! \n");
+
+    CRITICAL_SECTION() {
+        printf("Rolled a %d.. Critical printf again ! \n",roll);
+    }
+    
+    return 0;
+}
     
 #endif

--- a/mock/criticalsection.h
+++ b/mock/criticalsection.h
@@ -1,0 +1,14 @@
+#ifndef CRITICALSECTION_MOCK_H_
+#define CRITICALSECTION_MOCK_H_
+
+#include <stdint.h>
+#include <assert.h>
+
+#define CPU_CRITICAL_ENTER() { ++__mock_critical_depth; } 
+#define CPU_CRITICAL_EXIT() { --__mock_critical_depth; }
+#define CPU_SR_ALLOC() int16_t __mock_critical_depth = 0;
+
+#define mock_critsec_get_depth() (__mock_critical_depth)
+#define mock_critsec_is_critical() (__mock_critical_depth > 0 )
+
+#endif

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -3,6 +3,7 @@
 extern "C" {
 #include "../semaphores.h"
 #include "../mutex.h"
+#include "../criticalsection.h"
 }
 
 TEST_GROUP(SemaphoreMockTestGroup)
@@ -112,4 +113,80 @@ TEST(MutexMockTestGroup, CanReleaseMutex)
     os_mutex_release(mutex);
 
     CHECK_FALSE(mutex->acquired);
+}
+
+TEST_GROUP(CriticalSectionMockTestGroup)
+{};
+
+
+TEST(CriticalSectionMockTestGroup, CanAlloc)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CHECK_FALSE(mock_critsec_is_critical());
+}
+
+TEST(CriticalSectionMockTestGroup, CanEnterCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+    CRITICAL_SECTION_ENTER();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+}
+
+TEST(CriticalSectionMockTestGroup, CanExitCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+    CRITICAL_SECTION_ENTER();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanNestCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION_ENTER();
+    CRITICAL_SECTION_ENTER();
+    
+    CHECK_EQUAL(mock_critsec_get_depth(),2);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanUseCriticalSectionBlock)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION() {
+        CHECK_EQUAL(mock_critsec_get_depth(),1);
+    }
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanNestCriticalSectionBlock)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION() {
+
+        CRITICAL_SECTION() {
+            CHECK_EQUAL(mock_critsec_get_depth(),2);
+        }
+
+        CHECK_EQUAL(mock_critsec_get_depth(),1);
+    }
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
 }

--- a/tests/platform_mock_test.cpp
+++ b/tests/platform_mock_test.cpp
@@ -113,3 +113,79 @@ TEST(MutexMockTestGroup, CanReleaseMutex)
 
     CHECK_FALSE(mutex->acquired);
 }
+
+TEST_GROUP(CriticalSectionMockTestGroup)
+{};
+
+
+TEST(CriticalSectionMockTestGroup, CanAlloc)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CHECK_FALSE(mock_critsec_is_critical());
+}
+
+TEST(CriticalSectionMockTestGroup, CanEnterCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+    CRITICAL_SECTION_ENTER();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+}
+
+TEST(CriticalSectionMockTestGroup, CanExitCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+    CRITICAL_SECTION_ENTER();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanNestCritical)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION_ENTER();
+    CRITICAL_SECTION_ENTER();
+    
+    CHECK_EQUAL(mock_critsec_get_depth(),2);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),1);
+
+    CRITICAL_SECTION_EXIT();
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanUseCriticalSectionBlock)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION() {
+        CHECK_EQUAL(mock_critsec_get_depth(),1);
+    }
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}
+
+TEST(CriticalSectionMockTestGroup, CanNestCriticalSectionBlock)
+{
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION() {
+
+        CRITICAL_SECTION() {
+            CHECK_EQUAL(mock_critsec_get_depth(),2);
+        }
+
+        CHECK_EQUAL(mock_critsec_get_depth(),1);
+    }
+
+    CHECK_EQUAL(mock_critsec_get_depth(),0);
+}


### PR DESCRIPTION
For your consideration, here are two implementations of the critical section macros.

The CRITICAL_SECTION_ENTER / CRITICAL_SECTION_EXIT macros enable for checking of correct initialization **at compile-time** (with a reasonably explicit error message) but essentially behave exactly as the default API. It is possible to forget the _EXIT call.

The CRITICAL_SECTION() { ... } macro overcomes that inconvenience, but I'm not sure it's such a good idea. The implementation should be somewhat efficient but it's rather ugly and adds some useless overhead to the basic calls.

Mocks / testing will follow if you approve this design. Use case is provided in the "main" function.

Sorry for the messy presentation but this was hacked together at 1.10 am based on some notes I jotted down during a long, boring meeting today :-) The for-merge version will be clean.
