### PR TITLE
Malloc wrapper + Panic function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ add_executable(
     tests/semaphore_mock_test.cpp
     tests/mutex_mock_test.cpp
     tests/criticalsection_mock_test.cpp
+    tests/panic_mock_test.cpp
     tests/malloc_test.cpp
     xmalloc.c
+    panic.c
     mock/semaphores.c
     mock/mutex.c
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(
     tests/semaphore_mock_test.cpp
     tests/mutex_mock_test.cpp
     tests/criticalsection_mock_test.cpp
+    tests/malloc_test.cpp
+    xmalloc.c
     mock/semaphores.c
     mock/mutex.c
     )

--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,17 @@ testing.
 
 Currently we aim to support uc/OS-II and the mock platform for testing.
 
+# Memory Allocation
+Our custom wrapper `xmalloc` should be used whenever the program would die when `malloc` fails.
+It has the same prototype as standard `malloc` and always returns a valid value or hard crashes.
+
+# Fatal error handling
+Fatal error handling is done through the use of the `panic` function.
+
+## Use in testing
+`panic` is defined as a function pointer which allows one to replace it at runtime with a custom version to capture panics in tests.
+See `tests/panic_mock_test.cpp` for an example.
+
 # Semaphores
 
 ## Example

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Our custom wrapper `xmalloc` should be used whenever the program would die when 
 It has the same prototype as standard `malloc` and always returns a valid value or hard crashes.
 
 # Fatal error handling
-Fatal error handling is done through the use of the `panic` function.
+Fatal error handling is done through the use of the `PANIC` macro.
 
 ## Use in testing
 `panic` is defined as a function pointer which allows one to replace it at runtime with a custom version to capture panics in tests.

--- a/mock/mutex.c
+++ b/mock/mutex.c
@@ -1,10 +1,10 @@
-#include <stdlib.h>
 #include <assert.h>
 #include "../mutex.h"
+#include "../xmalloc.h"
 
 mutex_t *os_mutex_create(void)
 {
-    mutex_t *mutex = malloc(sizeof(mutex_t));
+    mutex_t *mutex = xmalloc(sizeof(mutex_t));
 
     mutex->acquired = false;
     mutex->acquired_count = 0;

--- a/mock/semaphores.c
+++ b/mock/semaphores.c
@@ -1,11 +1,11 @@
-#include <stdlib.h>
 #include <assert.h>
 #include "../semaphores.h"
+#include "../xmalloc.h"
 
 semaphore_t *os_semaphore_create(uint32_t count)
 {
     semaphore_t *sem;
-    sem = malloc(sizeof(semaphore_t));
+    sem = xmalloc(sizeof(semaphore_t));
 
     sem->count = count;
     sem->acquired_count = 0;

--- a/panic.c
+++ b/panic.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void panic_impl(const char *msg)
+{
+    printf("PANIC: %s\n", msg);
+
+#ifdef __unix__
+    abort();
+
+#endif
+}
+
+void (*panic)(const char *msg) = panic_impl;

--- a/panic.c
+++ b/panic.c
@@ -1,14 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void panic_impl(const char *msg)
+void panic_impl(const char *file, int line, const char *msg)
 {
-    printf("PANIC: %s\n", msg);
+    printf("PANIC (%s:%d): %s\n", file, line, msg);
 
 #ifdef __unix__
     abort();
-
 #endif
 }
 
-void (*panic)(const char *msg) = panic_impl;
+void (*panic)(const char *file, int line, const char *msg) = panic_impl;

--- a/panic.h
+++ b/panic.h
@@ -1,7 +1,9 @@
 #ifndef PANIC_H_
 #define PANIC_H_
 
+#define PANIC(m) panic(__FILE__, __LINE__, m)
+
 /** Panics with a given error message. */
-extern void (*panic)(const char *msg);
+extern void (*panic)(const char *file, int line, const char *msg);
 
 #endif

--- a/panic.h
+++ b/panic.h
@@ -1,0 +1,7 @@
+#ifndef PANIC_H_
+#define PANIC_H_
+
+/** Panics with a given error message. */
+extern void (*panic)(const char *msg);
+
+#endif

--- a/panic.h
+++ b/panic.h
@@ -1,9 +1,10 @@
 #ifndef PANIC_H_
 #define PANIC_H_
 
+/** Panics with a given error message and provides correct file and line
+ * informations to panic(). */
 #define PANIC(m) panic(__FILE__, __LINE__, m)
 
-/** Panics with a given error message. */
 extern void (*panic)(const char *file, int line, const char *msg);
 
 #endif

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -13,51 +13,56 @@ static void panic_counter(const char *file, int line, const char *msg)
 }
 
 TEST_GROUP(MallocTestGroup) {
+    int *array;
+
+    /* Find max value of size_t */
+    static const size_t max_size = (size_t) -1;
+
     void setup()
     {
         UT_PTR_SET(panic, panic_counter);
         panic_count = 0;
+        array = NULL;
+    }
+
+    void teardown()
+    {
+        xfree(array);
     }
 };
 
 TEST(MallocTestGroup, CanAllocateMemory)
 {
-    int *array = (int *)xmalloc(10*sizeof(int));
+    array = (int *)xmalloc(10*sizeof(int));
     array[9] = 42;
     CHECK_EQUAL(42, array[9]);
-    xfree(array);
 }
 
 TEST(MallocTestGroup, CreatingHugeAmountOfMemoryFails)
 {
-    /* Find max value of size_t */
-    size_t max_size = (size_t) -1;
-
     xmalloc(max_size);
     CHECK_EQUAL(1, panic_count);
 }
 
 TEST(MallocTestGroup, ZeroSizeDoesntCrash)
 {
-    void *ptr = xmalloc(0);
+    xmalloc(0);
     CHECK_EQUAL(0, panic_count);
 }
 
 TEST(MallocTestGroup, XReallocWorksToo)
 {
-    int *ptr = (int *)xmalloc(10*sizeof(int));
-    ptr[9] = 42;
-    ptr = (int *)xrealloc(ptr, 100);
-    ptr[99] = 43;
+    int *array = (int *)xmalloc(10*sizeof(int));
+    array[9] = 42;
+    array = (int *)xrealloc(array, 100);
+    array[99] = 43;
 
-    CHECK_EQUAL(42, ptr[9]);
-    CHECK_EQUAL(43, ptr[99]);
-    xfree(ptr);
+    CHECK_EQUAL(42, array[9]);
+    CHECK_EQUAL(43, array[99]);
 }
 
 TEST(MallocTestGroup, XReallocCanFailOnHugeSize)
 {
-    size_t max_size = (size_t) -1;
-    int *ptr = (int *)xrealloc(NULL, max_size);
+    xrealloc(NULL, max_size);
     CHECK_EQUAL(1, panic_count);
 }

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -13,4 +13,5 @@ TEST(MallocTestGroup, CanAllocateMemory)
     int *array = (int *)xmalloc(100);
     array[99] = 42;
     CHECK_EQUAL(42, array[99]);
+    xfree(array);
 }

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -42,3 +42,22 @@ TEST(MallocTestGroup, ZeroSizeDoesntCrash)
     void *ptr = xmalloc(0);
     CHECK_EQUAL(0, panic_count);
 }
+
+TEST(MallocTestGroup, XReallocWorksToo)
+{
+    int *ptr = (int *)xmalloc(10*sizeof(int));
+    ptr[9] = 42;
+    ptr = (int *)xrealloc(ptr, 100);
+    ptr[99] = 43;
+
+    CHECK_EQUAL(42, ptr[9]);
+    CHECK_EQUAL(43, ptr[99]);
+    xfree(ptr);
+}
+
+TEST(MallocTestGroup, XReallocCanFailOnHugeSize)
+{
+    size_t max_size = (size_t) -1;
+    int *ptr = (int *)xrealloc(NULL, max_size);
+    CHECK_EQUAL(1, panic_count);
+}

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -7,7 +7,7 @@ extern "C" {
 
 
 static int panic_count;
-static void panic_counter(const char *msg)
+static void panic_counter(const char *file, int line, const char *msg)
 {
     panic_count++;
 }

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -22,9 +22,9 @@ TEST_GROUP(MallocTestGroup) {
 
 TEST(MallocTestGroup, CanAllocateMemory)
 {
-    int *array = (int *)xmalloc(100);
-    array[99] = 42;
-    CHECK_EQUAL(42, array[99]);
+    int *array = (int *)xmalloc(10*sizeof(int));
+    array[9] = 42;
+    CHECK_EQUAL(42, array[9]);
     xfree(array);
 }
 

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -1,0 +1,16 @@
+#include "CppUTest/TestHarness.h"
+
+extern "C" {
+#include "../xmalloc.h"
+}
+
+TEST_GROUP(MallocTestGroup) {
+
+};
+
+TEST(MallocTestGroup, CanAllocateMemory)
+{
+    int *array = (int *)xmalloc(100);
+    array[99] = 42;
+    CHECK_EQUAL(42, array[99]);
+}

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -40,6 +40,5 @@ TEST(MallocTestGroup, CreatingHugeAmountOfMemoryFails)
 TEST(MallocTestGroup, ZeroSizeDoesntCrash)
 {
     void *ptr = xmalloc(0);
-    POINTERS_EQUAL(NULL, ptr);
     CHECK_EQUAL(0, panic_count);
 }

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -36,3 +36,10 @@ TEST(MallocTestGroup, CreatingHugeAmountOfMemoryFails)
     xmalloc(max_size);
     CHECK_EQUAL(1, panic_count);
 }
+
+TEST(MallocTestGroup, ZeroSizeDoesntCrash)
+{
+    void *ptr = xmalloc(0);
+    POINTERS_EQUAL(NULL, ptr);
+    CHECK_EQUAL(0, panic_count);
+}

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -2,10 +2,22 @@
 
 extern "C" {
 #include "../xmalloc.h"
+#include "../panic.h"
+}
+
+
+static int panic_count;
+static void panic_counter(const char *msg)
+{
+    panic_count++;
 }
 
 TEST_GROUP(MallocTestGroup) {
-
+    void setup()
+    {
+        UT_PTR_SET(panic, panic_counter);
+        panic_count = 0;
+    }
 };
 
 TEST(MallocTestGroup, CanAllocateMemory)
@@ -14,4 +26,13 @@ TEST(MallocTestGroup, CanAllocateMemory)
     array[99] = 42;
     CHECK_EQUAL(42, array[99]);
     xfree(array);
+}
+
+TEST(MallocTestGroup, CreatingHugeAmountOfMemoryFails)
+{
+    /* Find max value of size_t */
+    size_t max_size = (size_t) -1;
+
+    xmalloc(max_size);
+    CHECK_EQUAL(1, panic_count);
 }

--- a/tests/panic_mock_test.cpp
+++ b/tests/panic_mock_test.cpp
@@ -8,10 +8,12 @@ extern "C" {
 #define ERROR_MAX_LEN 1024
 
 static char error[ERROR_MAX_LEN];
+static int line;
 
-static void panic_dummy(const char *msg)
+static void panic_dummy(const char *file, int l, const char *msg)
 {
     strncpy(error, msg, ERROR_MAX_LEN);
+    line = l;
 }
 
 TEST_GROUP(PanicTestGroup) {
@@ -20,12 +22,14 @@ TEST_GROUP(PanicTestGroup) {
     {
         UT_PTR_SET(panic, panic_dummy);
         memset(error, 0, ERROR_MAX_LEN);
+        line = 0;
     }
 };
 
 TEST(PanicTestGroup, CanGetPanicMessage)
 {
     STRCMP_EQUAL("", error);
-    panic("lol");
+    PANIC("lol");
+    CHECK_EQUAL(__LINE__-1, line);
     STRCMP_EQUAL("lol", error);
 }

--- a/tests/panic_mock_test.cpp
+++ b/tests/panic_mock_test.cpp
@@ -1,0 +1,31 @@
+#include "CppUTest/TestHarness.h"
+#include <cstring>
+
+extern "C" {
+#include "../panic.h"
+}
+
+#define ERROR_MAX_LEN 1024
+
+static char error[ERROR_MAX_LEN];
+
+static void panic_dummy(const char *msg)
+{
+    strncpy(error, msg, ERROR_MAX_LEN);
+}
+
+TEST_GROUP(PanicTestGroup) {
+
+    void setup(void)
+    {
+        UT_PTR_SET(panic, panic_dummy);
+        memset(error, 0, ERROR_MAX_LEN);
+    }
+};
+
+TEST(PanicTestGroup, CanGetPanicMessage)
+{
+    STRCMP_EQUAL("", error);
+    panic("lol");
+    STRCMP_EQUAL("lol", error);
+}

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -1,7 +1,7 @@
 #include "xmalloc.h"
 #include "panic.h"
 
-void *xmalloc(size_t size)
+void* xmalloc(size_t size)
 {
     void *result;
 

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -1,0 +1,12 @@
+#include "xmalloc.h"
+
+void *xmalloc(size_t size)
+{
+    void *result;
+
+    result = malloc(size);
+
+    /* TODO if error : panic() */
+
+    return result;
+}

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -5,6 +5,10 @@ void* xmalloc(size_t size)
 {
     void *result;
 
+    if (size == 0) {
+        return NULL;
+    }
+
     result = malloc(size);
 
     if (result == NULL) {

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -18,3 +18,16 @@ void xfree(void *p)
 {
     free(p);
 }
+
+void* xrealloc(void *p, size_t size)
+{
+    void *result;
+
+    result = realloc(p, size);
+
+    if (result == NULL && size != 0) {
+        PANIC("out of memory!");
+    }
+
+    return result;
+}

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -1,4 +1,5 @@
 #include "xmalloc.h"
+#include "panic.h"
 
 void *xmalloc(size_t size)
 {
@@ -6,7 +7,9 @@ void *xmalloc(size_t size)
 
     result = malloc(size);
 
-    /* TODO if error : panic() */
+    if (result == NULL) {
+        panic("out of memory!");
+    }
 
     return result;
 }

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -10,3 +10,8 @@ void *xmalloc(size_t size)
 
     return result;
 }
+
+void xfree(void *p)
+{
+    free(p);
+}

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -8,7 +8,7 @@ void* xmalloc(size_t size)
     result = malloc(size);
 
     if (result == NULL) {
-        panic("out of memory!");
+        PANIC("out of memory!");
     }
 
     return result;

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -5,13 +5,9 @@ void* xmalloc(size_t size)
 {
     void *result;
 
-    if (size == 0) {
-        return NULL;
-    }
-
     result = malloc(size);
 
-    if (result == NULL) {
+    if (result == NULL && size != 0) {
         PANIC("out of memory!");
     }
 

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 void *xmalloc(size_t size);
+void xfree(void *p);
 
 
 #endif

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -1,0 +1,9 @@
+#ifndef MALLOC_H_
+#define MALLOC_H_
+
+#include <stdlib.h>
+
+void *xmalloc(size_t size);
+
+
+#endif

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -13,5 +13,8 @@ void* xmalloc(size_t size);
 /** Wrapper for free(). Should be used every time. */
 void xfree(void *p);
 
+/** Wrapper for realloc() similar to xmalloc. */
+void* xrealloc(void *p, size_t size);
+
 
 #endif

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -3,7 +3,14 @@
 
 #include <stdlib.h>
 
-void *xmalloc(size_t size);
+/** Safe wrapper for malloc.
+ *
+ * In case of an out of memory error, it will panic().
+ * This allows the developper to skip checking for error in cases where it is non recoverable.
+ */
+void* xmalloc(size_t size);
+
+/** Wrapper for free(). Should be used every time. */
 void xfree(void *p);
 
 


### PR DESCRIPTION
I wrote a wrapper for `malloc` to do error handling, as described in issue #18.
There is also an implementation of a function to report critical failures.
`panic` is defined as a pointer to be able to replace it with a test double when we need it.

Those wrappers are not feature-complete yet but they are already usable and I will add features in other PR.
Features I would like to see : 
- Find a way to make `malloc` fail to test if the code properly recovers.
- Add a location (file + line) information to `panic` message.
