### PR TITLE
Use CPPUmock for critical sections.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - sudo pip install pyaml jinja2
     - git clone https://github.com/cpputest/cpputest ../cpputest
     - pushd ../cpputest
-    - git checkout adb0ce70a614a4dd37657409403041989c38ce4a
+    - autoreconf
     - ./configure
     - make
     - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
     - sudo pip install pyaml jinja2
     - git clone https://github.com/cpputest/cpputest ../cpputest
     - pushd ../cpputest
+    - git checkout adb0ce70a614a4dd37657409403041989c38ce4a
     - ./configure
     - make
     - sudo make install
@@ -19,7 +20,6 @@ before_script:
     - mkdir build/
     - cd build/
     - cmake ..
-    - make
 
 script:
     - make

--- a/mock/criticalsection.c
+++ b/mock/criticalsection.c
@@ -1,0 +1,12 @@
+#include "../criticalsection.h"
+
+void critical_entered_impl(void)
+{
+}
+
+void critical_exited_impl(void)
+{
+}
+
+void (*critical_entered)(void) = critical_entered_impl;
+void (*critical_exited)(void) = critical_exited_impl;

--- a/mock/criticalsection.h
+++ b/mock/criticalsection.h
@@ -4,11 +4,11 @@
 #include <stdint.h>
 #include <assert.h>
 
-#define CPU_CRITICAL_ENTER() { ++__mock_critical_depth; } 
-#define CPU_CRITICAL_EXIT() { --__mock_critical_depth; }
-#define CPU_SR_ALLOC() int16_t __mock_critical_depth = 0;
+#define CPU_CRITICAL_ENTER() {critical_entered(); }
+#define CPU_CRITICAL_EXIT() {critical_exited(); }
+#define CPU_SR_ALLOC() {}
 
-#define mock_critsec_get_depth() (__mock_critical_depth)
-#define mock_critsec_is_critical() (__mock_critical_depth > 0 )
+extern void (*critical_entered)(void);
+extern void (*critical_exited)(void);
 
 #endif

--- a/package.yml
+++ b/package.yml
@@ -8,6 +8,7 @@ source:
 tests:
     - mock/semaphores.c
     - mock/mutex.c
+    - mock/criticalsection.c
     - tests/semaphore_mock_test.cpp
     - tests/mutex_mock_test.cpp
     - tests/criticalsection_mock_test.cpp

--- a/tests/criticalsection_capturing_mock.h
+++ b/tests/criticalsection_capturing_mock.h
@@ -1,0 +1,8 @@
+#ifndef CRITICALSECTION_CAPTURING_MOCK_H_
+#define CRITICALSECTION_CAPTURING_MOCK_H_
+
+/** Switches to mocking critical section enter and exit. */
+void criticalsection_use_capturing_mock();
+
+
+#endif

--- a/tests/criticalsection_mock_test.cpp
+++ b/tests/criticalsection_mock_test.cpp
@@ -91,3 +91,17 @@ TEST(CriticalSectionMockTestGroup, NestedWorksToo)
     mock().checkExpectations();
 }
 
+TEST(CriticalSectionMockTestGroup, CanBreakFromSection)
+{
+    CRITICAL_SECTION_ALLOC();
+    mock().expectOneCall("CPU_CRITICAL_ENTER");
+    mock().expectOneCall("CPU_CRITICAL_EXIT");
+
+    CRITICAL_SECTION() {
+        break;
+        FAIL("Should not get there !");
+    }
+
+    mock().checkExpectations();
+}
+

--- a/tests/criticalsection_mock_test.cpp
+++ b/tests/criticalsection_mock_test.cpp
@@ -29,6 +29,7 @@ TEST_GROUP(CriticalSectionMockTestGroup)
     void setup(void)
     {
         criticalsection_use_capturing_mock();
+        mock().strictOrder();
     }
 
     void teardown(void)

--- a/tests/criticalsection_mock_test.cpp
+++ b/tests/criticalsection_mock_test.cpp
@@ -74,14 +74,19 @@ TEST(CriticalSectionMockTestGroup, NestedWorksToo)
 {
     CRITICAL_SECTION_ALLOC();
     mock().expectOneCall("CPU_CRITICAL_ENTER");
+    mock().expectOneCall("A");
     mock().expectOneCall("CPU_CRITICAL_ENTER");
+    mock().expectOneCall("B");
     mock().expectOneCall("CPU_CRITICAL_EXIT");
+    mock().expectOneCall("C");
     mock().expectOneCall("CPU_CRITICAL_EXIT");
 
     CRITICAL_SECTION() {
+        mock().actualCall("A");
         CRITICAL_SECTION() {
-
+            mock().actualCall("B");
         }
+        mock().actualCall("C");
     }
     mock().checkExpectations();
 }


### PR DESCRIPTION
This allows for easier testing, since we can put in a test that we expect critical sections macro to be called (see the new tests for example).

This adds the possibility to test for critical sections in other functions, example : 

``` cpp
TEST(SomeTestGroup, SomeTest)
{
    criticalsection_use_capturing_mock();
    mock().expectOneCall("CPU_CRITICAL_ENTER");
    mock().expectOneCall("CPU_CRITICAL_EXIT");

    foo(); // foo should contain atomic code.

    mock().checkExpectations();
    mock.clear();
}
```
