### PR TITLE
Add support for variable arguments to PANIC

### DIFF
--- a/panic.c
+++ b/panic.c
@@ -1,9 +1,16 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 void panic_impl(const char *file, int line, const char *msg, ...)
 {
-    printf("PANIC (%s:%d): %s\n", file, line, msg);
+    va_list ap;
+    va_start(ap, msg);
+
+    printf("PANIC (%s:%d): ", file, line);
+    vprintf(msg, ap);
+
+    va_end(ap);
 
 #ifdef __unix__
     abort();

--- a/panic.c
+++ b/panic.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void panic_impl(const char *file, int line, const char *msg)
+void panic_impl(const char *file, int line, const char *msg, ...)
 {
     printf("PANIC (%s:%d): %s\n", file, line, msg);
 
@@ -10,4 +10,4 @@ void panic_impl(const char *file, int line, const char *msg)
 #endif
 }
 
-void (*panic)(const char *file, int line, const char *msg) = panic_impl;
+void (*panic)(const char *file, int line, const char *msg, ...) = panic_impl;

--- a/panic.h
+++ b/panic.h
@@ -2,9 +2,11 @@
 #define PANIC_H_
 
 /** Panics with a given error message and provides correct file and line
- * informations to panic(). */
-#define PANIC(m) panic(__FILE__, __LINE__, m)
+ * informations to panic().
+ * It supports printf-like variable arguments list :
+ * PANIC("error %d", 1234); is a valid invocation. */
+#define PANIC(m, ...) panic(__FILE__, __LINE__, m, ##__VA_ARGS__)
 
-extern void (*panic)(const char *file, int line, const char *msg);
+extern void (*panic)(const char *file, int line, const char *msg, ...);
 
 #endif

--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -7,7 +7,7 @@ extern "C" {
 
 
 static int panic_count;
-static void panic_counter(const char *file, int line, const char *msg)
+static void panic_counter(const char *file, int line, const char *msg, ...)
 {
     panic_count++;
 }

--- a/tests/panic_mock_test.cpp
+++ b/tests/panic_mock_test.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include <cstring>
+#include <cstdio>
 
 extern "C" {
 #include "../panic.h"
@@ -10,10 +11,13 @@ extern "C" {
 static char error[ERROR_MAX_LEN];
 static int line;
 
-static void panic_dummy(const char *file, int l, const char *msg)
+static void panic_dummy(const char *file, int l, const char *msg, ...)
 {
-    strncpy(error, msg, ERROR_MAX_LEN);
     line = l;
+    va_list ap;
+    va_start(ap, msg);
+    vsprintf(error, msg, ap);
+    va_end(ap);
 }
 
 TEST_GROUP(PanicTestGroup) {
@@ -32,4 +36,10 @@ TEST(PanicTestGroup, CanGetPanicMessage)
     PANIC("lol");
     CHECK_EQUAL(__LINE__-1, line);
     STRCMP_EQUAL("lol", error);
+}
+
+TEST(PanicTestGroup, CanUseVariableArguments)
+{
+    PANIC("foobar %d", 123);
+    STRCMP_EQUAL("foobar 123", error);
 }


### PR DESCRIPTION
Now PANIC can be used with printf-like variable arguments, which is useful to provide more detailed informations about a crash.

Sorry, this is a big commit, but it was hard splitting it into smaller meaningful patches.
