### PR TITLE
Xmalloc: Fail if size == 0

### DIFF
--- a/tests/malloc_test.cpp
+++ b/tests/malloc_test.cpp
@@ -44,10 +44,10 @@ TEST(MallocTestGroup, CreatingHugeAmountOfMemoryFails)
     CHECK_EQUAL(1, panic_count);
 }
 
-TEST(MallocTestGroup, ZeroSizeDoesntCrash)
+TEST(MallocTestGroup, ZeroSizeDoesCrash)
 {
     xmalloc(0);
-    CHECK_EQUAL(0, panic_count);
+    CHECK_EQUAL(1, panic_count);
 }
 
 TEST(MallocTestGroup, XReallocWorksToo)

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -5,9 +5,13 @@ void* xmalloc(size_t size)
 {
     void *result;
 
+    if (size == 0) {
+        PANIC("invalid alloc: zero byte");
+    }
+
     result = malloc(size);
 
-    if (result == NULL && size != 0) {
+    if (result == NULL) {
         PANIC("out of memory!");
     }
 

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -7,6 +7,8 @@
  *
  * In case of an out of memory error, it will panic().
  * This allows the developper to skip checking for error in cases where it is non recoverable.
+ *
+ * @note xmalloc also panics if size == 0.
  */
 void* xmalloc(size_t size);
 


### PR DESCRIPTION
After a discussion with @31415us we propose that `xmalloc` should fail if the size is zero because it is probably a bug. We did not have any real use case where `malloc(0)` was legit. We keep existing behavior for `xrealloc` because there were use cases.
