### PR TITLE
Threading api with uCOS-III implementation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -175,3 +175,40 @@ CRIICAL_SECTION() {
 CHECK_FALSE(mock_critsec_is_critical());
 ```
 
+# Threading
+## Usage
+```cpp
+/* Creates a 2048 bytes stack. */
+THREAD_STACK mystack[2048];
+os_thread_t mythread;
+
+const int myprio = 10;
+
+void mymain(void *context)
+{
+    while (1) {
+        /* ... */
+
+        do_something();
+
+        /* wait 1000 milliseconds */
+        os_thread_sleep(1000);
+
+        /* ... */
+    }
+}
+
+void main(void) {
+    /* Inits all the operating system structures. */
+    os_init();
+
+    /* Run thread. Last parameter will be passed as context to the thread */
+    os_thread_create(&mythread, mymain, mystack, sizeof(mystack), "my thread", myprio, NULL);
+
+    /* Same thread but with a dynamically allocated stack. */
+    os_thread_create(&mythread, mymain, NULL, 2048, "my thread", myprio, NULL);
+
+    /* Starts multi-tasking. */
+    thread_run();
+}
+```

--- a/README.markdown
+++ b/README.markdown
@@ -192,7 +192,7 @@ void mymain(void *context)
         do_something();
 
         /* wait 1000 milliseconds */
-        os_thread_sleep(1000);
+        os_thread_sleep_ms(1000);
 
         /* ... */
     }

--- a/README.markdown
+++ b/README.markdown
@@ -188,8 +188,8 @@ void mymain(void *context)
 
         do_something();
 
-        /* wait 1000 milliseconds */
-        os_thread_sleep_ms(1000);
+        /* wait 1000000 microseconds */
+        os_thread_sleep_us(1000000);
 
         /* ... */
     }

--- a/package.yml
+++ b/package.yml
@@ -5,6 +5,9 @@ source:
     - xmalloc.c
     - panic.c
 
+target.arm:
+    - ucos-iii/threading.c
+
 tests:
     - mock/semaphores.c
     - mock/mutex.c

--- a/threading.h
+++ b/threading.h
@@ -20,6 +20,6 @@ void os_run(void);
 void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size_t stack_size, const char *name, unsigned int prio, void *arg);
 
 /** Sleep for n milliseconds */
-void os_thread_sleep(uint32_t millisec);
+void os_thread_sleep_ms(uint32_t millisec);
 
 #endif /* THREADING_H_ */

--- a/threading.h
+++ b/threading.h
@@ -19,7 +19,10 @@ void os_run(void);
 /** Creates a new thread. */
 void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size_t stack_size, const char *name, unsigned int prio, void *arg);
 
-/** Sleep for n milliseconds */
-void os_thread_sleep_ms(uint32_t millisec);
+/** Sleep for ms milliseconds or less */
+void os_thread_sleep_ms(uint32_t ms);
+
+/** Sleep for at least ms milliseconds */
+void os_thread_sleep_least_ms(uint32_t ms);
 
 #endif /* THREADING_H_ */

--- a/threading.h
+++ b/threading.h
@@ -1,0 +1,25 @@
+#ifndef THREADING_H_
+#define THREADING_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __unix__
+#include "mock/threading.h"
+#else
+#include "ucos-iii/threading.h"
+#endif
+
+/** Initializes OS. */
+void os_init(void);
+
+/** Starts scheduling the created threads. Never returns */
+void os_run(void);
+
+/** Creates a new thread. */
+void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size_t stack_size, const char *name, unsigned int prio, void *arg);
+
+/** Sleep for n milliseconds */
+void os_thread_sleep(uint32_t millisec);
+
+#endif /* THREADING_H_ */

--- a/threading.h
+++ b/threading.h
@@ -19,10 +19,10 @@ void os_run(void);
 /** Creates a new thread. */
 void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size_t stack_size, const char *name, unsigned int prio, void *arg);
 
-/** Sleep for ms milliseconds or less */
-void os_thread_sleep_ms(uint32_t ms);
+/** Sleep for us microseconds or less */
+void os_thread_sleep_us(uint32_t us);
 
-/** Sleep for at least ms milliseconds */
-void os_thread_sleep_least_ms(uint32_t ms);
+/** Sleep for at least us microseconds */
+void os_thread_sleep_least_us(uint32_t us);
 
 #endif /* THREADING_H_ */

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -43,6 +43,9 @@ void os_run(void)
        PANIC("Failed to configure scheduler");
     }
 
+    /* init context switch timer for frequency OS_CFG_TICK_RATE_HZ */
+    OS_CPU_SysTickInit(CPU_CFG_CPU_CORE_FREQ / OS_CFG_TICK_RATE_HZ);
+
     OSStart(&err);
 
     if (err != OS_ERR_NONE) {

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -102,13 +102,35 @@ void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size
     }
 }
 
-void os_thread_sleep_ms(uint32_t millisec)
+/* Thread waits ms milliseconds or less. */
+void os_thread_sleep_ms(uint32_t ms)
 {
     OS_ERR err;
     CPU_INT16U hr = 0;
     CPU_INT16U min = 0;
     CPU_INT16U sec = 0;
-    OSTimeDlyHMSM(hr, min, sec, millisec, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+
+    if (ms == 0) {
+        return;
+    }
+
+    /* uCOS-III will round to the nearest tick, even if that means no delay. */
+    OSTimeDlyHMSM(hr, min, sec, (CPU_INT32U) ms, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+}
+
+/* Thread waits at least ms milliseconds. */
+void os_thread_sleep_least_ms(uint32_t ms)
+{
+    OS_ERR err;
+
+    if (ms == 0) {
+        return;
+    }
+
+    /* round up to gurarantee a wait period of ms milliseconds */
+    OS_TICK dly = (OS_TICK) (ms - 1) * OS_CFG_TICK_RATE_HZ / 1000  + 1;
+
+    OSTimeDly(dly, OS_OPT_TIME_DLY, &err);
 }
 
 /* __malloc_lock() may be called several times before __malloc_unlock()

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -88,7 +88,7 @@ void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size
     }
 }
 
-void os_thread_sleep(uint32_t millisec)
+void os_thread_sleep_ms(uint32_t millisec)
 {
     OS_ERR err;
     OSTimeDlyHMSM(0, 0, 0, millisec, OS_OPT_TIME_HMSM_NON_STRICT, &err);

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -102,33 +102,34 @@ void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size
     }
 }
 
-/* Thread waits ms milliseconds or less. */
-void os_thread_sleep_ms(uint32_t ms)
+/* Thread waits us microseconds or less. */
+void os_thread_sleep_us(uint32_t us)
 {
     OS_ERR err;
     CPU_INT16U hr = 0;
     CPU_INT16U min = 0;
     CPU_INT16U sec = 0;
+    CPU_INT32U ms = us / 1000;
 
     if (ms == 0) {
         return;
     }
 
     /* uCOS-III will round to the nearest tick, even if that means no delay. */
-    OSTimeDlyHMSM(hr, min, sec, (CPU_INT32U) ms, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+    OSTimeDlyHMSM(hr, min, sec, ms, OS_OPT_TIME_HMSM_NON_STRICT, &err);
 }
 
-/* Thread waits at least ms milliseconds. */
-void os_thread_sleep_least_ms(uint32_t ms)
+/* Thread waits at least us microseconds. */
+void os_thread_sleep_least_us(uint32_t us)
 {
     OS_ERR err;
 
-    if (ms == 0) {
+    if (us == 0) {
         return;
     }
 
-    /* round up to gurarantee a wait period of ms milliseconds */
-    OS_TICK dly = (OS_TICK) (ms - 1) * OS_CFG_TICK_RATE_HZ / 1000  + 1;
+    /* round up to gurarantee a wait period of us microseconds */
+    OS_TICK dly = (OS_TICK) (us - 1) * OS_CFG_TICK_RATE_HZ / 1000000  + 1;
 
     OSTimeDly(dly, OS_OPT_TIME_DLY, &err);
 }

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <os.h>
+#include <os_cfg_app.h>
 #include "../threading.h"
 #include "../panic.h"
 #include "../mutex.h"

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -1,0 +1,199 @@
+#include <string.h>
+#include <os.h>
+#include "../threading.h"
+#include "../panic.h"
+#include "../mutex.h"
+#include "../xmalloc.h"
+
+/* default newlib context */
+struct _reent *default_newlib_reent;
+
+/* mutex to guard malloc access */
+mutex_t malloc_mutex;
+
+
+void os_init(void)
+{
+    CPU_Init();
+
+    OS_ERR err;
+    OSInit(&err);
+
+    if (err != OS_ERR_NONE) {
+       PANIC("Failed to init uCOS-III");
+    }
+
+    default_newlib_reent = _impure_ptr;
+
+    os_mutex_init(&malloc_mutex);
+}
+
+void os_run(void)
+{
+    OS_ERR err;
+
+    OSSchedRoundRobinCfg(true, 1, &err);
+
+    if (err != OS_ERR_NONE) {
+       PANIC("Failed to configure scheduler");
+    }
+
+    OSStart(&err);
+
+    if (err != OS_ERR_NONE) {
+        PANIC("Failed to start uCOS-III");
+    }
+}
+
+void os_thread_create(os_thread_t *thread, void (*fn)(void *), void *stack, size_t stack_size, const char *name, unsigned int prio, void *arg)
+{
+    OS_ERR err;
+
+    /* initialize newlib's reentrancy structure */
+    _REENT_INIT_PTR(&thread->newlib_reent);
+
+    /* uCOS-III priority: from 2 up to OS_CFG_PRIO_MAX - 3 */
+    prio += 2;
+
+    if (prio > OS_CFG_PRIO_MAX - 3) {
+        PANIC("Invalid thread priority");
+    }
+
+    if (stack == NULL) {
+        stack = xmalloc(stack_size);
+        thread->dyn_alloc_stack = true;
+    } else {
+        thread->dyn_alloc_stack = false;
+    }
+    thread->stack_base = stack;
+    thread->stack_size = stack_size;
+
+    /* create a uCOS-III task */
+    OSTaskCreate(&thread->ucos_tcb,          /* Address of TCB assigned to the task      */
+                 (CPU_CHAR *)name,           /* Name you want to give the task           */
+                 fn,                         /* Address of the task itself               */
+                 arg,                        /* Argument pointer                         */
+                 prio,                       /* Priority you want to assign to the task  */
+                 stack,                      /* Base address of task’s stack             */
+                 0,                          /* Watermark limit for stack growth         */
+                 stack_size/sizeof(CPU_STK), /* Stack size in number of CPU_STK elements */
+                 0,                          /* Size of task message queue               */
+                 0,                          /* Time quanta (in number of ticks)         */
+                 thread,                     /* Extension pointer                        */
+                 OS_OPT_TASK_STK_CHK | OS_OPT_TASK_SAVE_FP, /* Options                   */
+                 &err);                                     /* Error code                */
+
+    if (err != OS_ERR_NONE) {
+        PANIC("Failed to create thread");
+    }
+}
+
+void os_thread_sleep(uint32_t millisec)
+{
+    OS_ERR err;
+    OSTimeDlyHMSM(0, 0, 0, millisec, OS_OPT_TIME_HMSM_NON_STRICT, &err);
+}
+
+/* __malloc_lock() may be called several times before __malloc_unlock()
+   uCOS-III mutexes can be taken multiple times by the owner. */
+void __malloc_lock(void)
+{
+    os_mutex_take(&malloc_mutex);
+}
+
+void __malloc_unlock(void)
+{
+    os_mutex_release(&malloc_mutex);
+}
+
+
+/* OS hooks */
+
+void OSTaskReturnHook(OS_TCB *p_tcb)
+{
+    os_thread_t *t = (os_thread_t *)p_tcb->ExtPtr;
+
+    if (t == NULL) {
+        return;
+    }
+
+    if (t->dyn_alloc_stack) {
+        xfree(t->stack_base);
+    }
+}
+
+void OSTaskSwHook(void)
+{
+#if OS_CFG_TASK_PROFILE_EN > 0u
+    CPU_TS  ts;
+#endif
+#ifdef  CPU_CFG_INT_DIS_MEAS_EN
+    CPU_TS  int_dis_time;
+#endif
+
+#if (defined(TRACE_CFG_EN) && (TRACE_CFG_EN > 0u))
+    /* Record the event. */
+    TRACE_OS_TASK_SWITCHED_IN(OSTCBHighRdyPtr);
+#endif
+
+#if OS_CFG_TASK_PROFILE_EN > 0u
+    ts = OS_TS_GET();
+    if (OSTCBCurPtr != OSTCBHighRdyPtr) {
+        OSTCBCurPtr->CyclesDelta  = ts - OSTCBCurPtr->CyclesStart;
+        OSTCBCurPtr->CyclesTotal += (OS_CYCLES)OSTCBCurPtr->CyclesDelta;
+    }
+    OSTCBHighRdyPtr->CyclesStart = ts;
+#endif
+
+#ifdef  CPU_CFG_INT_DIS_MEAS_EN
+    /* Keep track of per-task interrupt disable time */
+    int_dis_time = CPU_IntDisMeasMaxCurReset();
+    if (OSTCBCurPtr->IntDisTimeMax < int_dis_time) {
+        OSTCBCurPtr->IntDisTimeMax = int_dis_time;
+    }
+#endif
+
+#if OS_CFG_SCHED_LOCK_TIME_MEAS_EN > 0u
+    /* Keep track of per-task scheduler lock time */
+    if (OSTCBCurPtr->SchedLockTimeMax < OSSchedLockTimeMaxCur) {
+        OSTCBCurPtr->SchedLockTimeMax = OSSchedLockTimeMaxCur;
+    }
+    OSSchedLockTimeMaxCur = (CPU_TS)0;
+#endif
+
+    /* switch newlib context */
+    os_thread_t *t = (os_thread_t *)OSTCBHighRdyPtr->ExtPtr;
+    if (t != NULL) {
+        _impure_ptr = &t->newlib_reent;
+    } else {
+        /* ExtPtr in uCOS-III internal tasks is initialized with NULL.
+           Those tasks share the same newlib context, since it isn't used anyway */
+        _impure_ptr = default_newlib_reent;
+    }
+}
+
+void OSInitHook(void)
+{
+    OS_CPU_ExceptStkBase = (CPU_STK *)(OSCfg_ISRStkBasePtr + OSCfg_ISRStkSize);
+    OS_CPU_ExceptStkBase = (CPU_STK *)((CPU_STK)(OS_CPU_ExceptStkBase) & 0xFFFFFFF8);
+}
+
+void OSIdleTaskHook(void)
+{
+
+}
+
+void OSTaskCreateHook(OS_TCB *p_tcb)
+{
+
+}
+
+void OSTimeTickHook(void)
+{
+
+}
+
+void OSTaskDelHook(OS_TCB *p_tcb)
+{
+
+}

--- a/ucos-iii/threading.h
+++ b/ucos-iii/threading.h
@@ -1,0 +1,20 @@
+#ifndef UCOS_III_THREADING_H_
+#define UCOS_III_THREADING_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <os.h>
+
+#define THREAD_STACK __attribute((section(".noinit"))) uint8_t
+
+typedef struct {
+    OS_TCB ucos_tcb;
+    struct _reent newlib_reent;
+    bool dyn_alloc_stack;
+    void *stack_base;
+    size_t stack_size;
+} os_thread_t;
+
+#endif


### PR DESCRIPTION
The API is mostly based on what @antoinealb did in PR #23.
The biggest difference is, that the thread's data structure `os_thread_t` can be statically allocated, which must be passed to `os_thread_create()` as an additional argument. (If I remember correctly, we discussed the malloc-topic already)
It also implements newlib's malloc locking and switches newlib's context on every thread context switch. (This still needs to be tested)
