### PR TITLE
Unused variable warning in critical section

### DIFF
--- a/criticalsection.h
+++ b/criticalsection.h
@@ -30,7 +30,7 @@
 /** Critical section enter macro
  * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand
  */
-#define CRITICAL_SECTION_ENTER() {if(sizeof(__critical_alloc)>0){CPU_CRITICAL_ENTER();}}
+#define CRITICAL_SECTION_ENTER() {if(sizeof(__critical_alloc)>0){CPU_CRITICAL_ENTER();(void) __critctrl;}}
 
 /** Critical section exit macro
  * \warn Will generate a compile-time bug if CRITICAL_SECTION_ALLOC hasn't been called beforehand


### PR DESCRIPTION
`CRITICAL_SECTION_ALLOC()` declares a `int16_t __critctrl` variable, which is not used in `CRITICAL_SECTION_ENTER()` and `CRITICAL_SECTION_EXIT()` and therefore generates a compiler warning.
How about adding a cast to void?
