### PR TITLE
Add local timestamp functions (fix issue #42)

### DIFF
--- a/mock/timestamp.cpp
+++ b/mock/timestamp.cpp
@@ -1,0 +1,9 @@
+#include "CppUTestExt/MockSupport.h"
+extern "C" {
+#include "../timestamp.h"
+}
+
+uint32_t os_timestamp_get(void)
+{
+    return mock().actualCall("os_timestamp_get").returnIntValue();
+}

--- a/package.yml
+++ b/package.yml
@@ -10,6 +10,7 @@ target.arm:
     - ucos-iii/threading.c
     - ucos-iii/semaphore.c
     - ucos-iii/mutex.c
+    - ucos-iii/timestamp.c
 
 tests:
     - mock/semaphore.c

--- a/package.yml
+++ b/package.yml
@@ -4,6 +4,7 @@ depends:
 source:
     - xmalloc.c
     - panic.c
+    - timestamp.c
 
 target.arm:
     - ucos-iii/threading.c
@@ -14,8 +15,10 @@ tests:
     - mock/semaphore.c
     - mock/mutex.c
     - mock/criticalsection.c
+    - mock/timestamp.cpp
     - tests/semaphore_mock_test.cpp
     - tests/mutex_mock_test.cpp
     - tests/criticalsection_mock_test.cpp
     - tests/panic_mock_test.cpp
     - tests/malloc_test.cpp
+    - tests/timestamp_test.cpp

--- a/tests/timestamp_test.cpp
+++ b/tests/timestamp_test.cpp
@@ -1,0 +1,47 @@
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+extern "C" {
+#include "../timestamp.h"
+}
+
+TEST_GROUP(TimestampTestGroup)
+{
+    void teardown()
+    {
+        mock().clear();
+    }
+};
+
+TEST(TimestampTestGroup, CanGetTime)
+{
+    uint32_t time;
+
+    mock().expectOneCall("os_timestamp_get").andReturnValue(42);
+    time = os_timestamp_get();
+    CHECK_EQUAL(42, time);
+}
+
+TEST(TimestampTestGroup, CanUpdateTime)
+{
+    uint32_t time = 0;
+    mock().expectOneCall("os_timestamp_get").andReturnValue(42);
+    mock().expectOneCall("os_timestamp_get").andReturnValue(100);
+
+    os_timestamp_diff_and_update(&time);
+    CHECK_EQUAL(42, time);
+
+    os_timestamp_diff_and_update(&time);
+    CHECK_EQUAL(100, time);
+}
+
+TEST(TimestampTestGroup, CanGetDifference)
+{
+    uint32_t time=1000, diff;
+    mock().expectOneCall("os_timestamp_get").andReturnValue(2500);
+
+    diff = os_timestamp_diff_and_update(&time);
+    CHECK_EQUAL(1500, diff)
+}
+
+

--- a/timestamp.c
+++ b/timestamp.c
@@ -1,0 +1,10 @@
+#include "timestamp.h"
+
+uint32_t os_timestamp_diff_and_update(uint32_t *ts)
+{
+    uint32_t diff, now;
+    now = os_timestamp_get();
+    diff = now - *ts;
+    *ts = now;
+    return diff;
+}

--- a/timestamp.h
+++ b/timestamp.h
@@ -1,0 +1,12 @@
+#ifndef TIMESTAMP_H_
+#define TIMESTAMP_H_y
+
+#include <stdint.h>
+
+/** Returns the time since the boot of the system in microseconds. */
+uint32_t os_timestamp_get(void);
+
+/** Updates the given timestamp and returns the difference. */
+uint32_t os_timestamp_diff_and_update(uint32_t *ts);
+
+#endif

--- a/timestamp.h
+++ b/timestamp.h
@@ -1,5 +1,5 @@
 #ifndef TIMESTAMP_H_
-#define TIMESTAMP_H_y
+#define TIMESTAMP_H_
 
 #include <stdint.h>
 

--- a/ucos-iii/threading.c
+++ b/ucos-iii/threading.c
@@ -13,6 +13,9 @@ static struct _reent *default_newlib_reent;
 static mutex_t malloc_mutex;
 static bool os_running = false;
 
+/* timer tick counter */
+uint32_t os_sys_ticks = 0;
+
 void os_init(void)
 {
     CPU_Init();
@@ -153,6 +156,9 @@ void __malloc_unlock(void)
 
 void sys_tick_handler(void)
 {
+    /* count timer ticks */
+    os_sys_ticks += 1;
+
     /* call uCOS Port SysTick handler */
     OS_CPU_SysTickHandler();
 }

--- a/ucos-iii/threading.h
+++ b/ucos-iii/threading.h
@@ -17,4 +17,6 @@ typedef struct {
     size_t stack_size;
 } os_thread_t;
 
+extern uint32_t os_sys_ticks;
+
 #endif

--- a/ucos-iii/timestamp.c
+++ b/ucos-iii/timestamp.c
@@ -4,8 +4,11 @@
 #include "threading.h"
 #include <os_cfg_app.h>
 
-#define REG_SYSTICK_RVR             (*(uint32_t *)0xE000E014)
-#define REG_SYSTICK_CVR             (*(uint32_t *)0xE000E018)
+/* SysTick reload value register */
+#define REG_SYSTICK_RVR             (*(volatile uint32_t *)0xE000E014)
+
+/* SysTick current value register */
+#define REG_SYSTICK_CVR             (*(volatile uint32_t *)0xE000E018)
 
 uint32_t os_timestamp_get(void)
 {
@@ -26,7 +29,7 @@ uint32_t os_timestamp_get(void)
     /* calculate time in microseconds */
     timestamp = ticks * (1000000 / OS_CFG_TICK_RATE_HZ);
 
-    /* SysTick is counting down */
+    /* SysTick is counting down, subtract from reload value */
     cur = REG_SYSTICK_RVR - cur;
 
     /* add current timer value */

--- a/ucos-iii/timestamp.c
+++ b/ucos-iii/timestamp.c
@@ -1,0 +1,36 @@
+
+#include <stdint.h>
+#include "../criticalsection.h"
+#include "threading.h"
+#include <os_cfg_app.h>
+
+#define REG_SYSTICK_RVR             (*(uint32_t *)0xE000E014)
+#define REG_SYSTICK_CVR             (*(uint32_t *)0xE000E018)
+
+uint32_t os_timestamp_get(void)
+{
+    uint32_t cur, ticks, timestamp;
+
+    CRITICAL_SECTION_ALLOC();
+
+    CRITICAL_SECTION_ENTER();
+
+    /* read systick timer current value */
+    cur = REG_SYSTICK_CVR;
+
+    /* read timestamp counter */
+    ticks = os_sys_ticks;
+
+    CRITICAL_SECTION_EXIT();
+
+    /* calculate time in microseconds */
+    timestamp = ticks * (1000000 / OS_CFG_TICK_RATE_HZ);
+
+    /* SysTick is counting down */
+    cur = REG_SYSTICK_RVR - cur;
+
+    /* add current timer value */
+    timestamp += cur / (CPU_CFG_CPU_CORE_FREQ / 1000000);
+
+    return timestamp;
+}

--- a/ucos-iii/timestamp.c
+++ b/ucos-iii/timestamp.c
@@ -4,6 +4,13 @@
 #include "threading.h"
 #include <os_cfg_app.h>
 
+/* Note:
+ * For the timestamps to be precise, the defines CPU_CFG_CPU_CORE_FREQ and
+ * OS_CFG_TICK_RATE_HZ must fulfill following conditions:
+ *  - CPU_CFG_CPU_CORE_FREQ must be a mutiple of 1MHz.
+ *  - OS_CFG_TICK_RATE_HZ must be divisor of 1MHz.
+ */
+
 /* SysTick reload value register */
 #define REG_SYSTICK_RVR             (*(volatile uint32_t *)0xE000E014)
 


### PR DESCRIPTION
So it implements the function we talked about in #42 with mock support (see the tests for info on how to use this). I did not implement it for uc/OS-III yet, because I don't have a working system with me now. @nuft could do it maybe ?

I would prefer to have the ucOS implementation before merge, to avoid splitting the functionality list between the test version and the real version.
