### PR TITLE
Semaphore naming

### DIFF
--- a/mock/semaphore.c
+++ b/mock/semaphore.c
@@ -31,7 +31,7 @@ bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout)
     return os_semaphore_try(sem);
 }
 
-void os_semaphore_release(semaphore_t *sem)
+void os_semaphore_signal(semaphore_t *sem)
 {
     sem->count ++;
 }

--- a/mock/semaphore.c
+++ b/mock/semaphore.c
@@ -8,7 +8,7 @@ void os_semaphore_init(semaphore_t *sem, uint32_t count)
     sem->acquired_count = 0;
 }
 
-void os_semaphore_take(semaphore_t *sem)
+void os_semaphore_wait(semaphore_t *sem)
 {
     assert(sem->count > 0);
     sem->count--;

--- a/semaphore.h
+++ b/semaphore.h
@@ -13,16 +13,22 @@
 /** Initializes the semaphore with given count value. */
 void os_semaphore_init(semaphore_t *sem, uint32_t count);
 
-/** Takes the semaphore if available, blocks if not available. */
-void os_semaphore_take(semaphore_t *sem);
+/** Decrements the semaphore if available, blocks if not available. */
+void os_semaphore_wait(semaphore_t *sem);
 
-/** Takes the semaphore non-blocking */
+/** Decrements the semaphore non-blocking.
+ *
+ * @return true if the semaphore was decremented, false if it would have blocked.
+ */
 bool os_semaphore_try(semaphore_t *sem);
 
-/** Acquire the semaphore blocking with timeout [us] */
+/** Tries to decrements the semaphore before a given timeout (in us).
+ *
+ * @return true if it was decremented, false if it timed out.
+ */
 bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout);
 
-/** Releases (posts) the semaphore. */
+/** Increments the semaphore. */
 void os_semaphore_release(semaphore_t *sem);
 
 #endif

--- a/semaphore.h
+++ b/semaphore.h
@@ -29,6 +29,6 @@ bool os_semaphore_try(semaphore_t *sem);
 bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout);
 
 /** Increments the semaphore. */
-void os_semaphore_release(semaphore_t *sem);
+void os_semaphore_signal(semaphore_t *sem);
 
 #endif

--- a/tests/semaphore_mock_test.cpp
+++ b/tests/semaphore_mock_test.cpp
@@ -19,7 +19,7 @@ TEST(SemaphoreMockTestGroup, CanTakeSemaphore)
 {
     os_semaphore_init(&sem, 1);
 
-    os_semaphore_take(&sem);
+    os_semaphore_wait(&sem);
     CHECK_EQUAL(0, sem.count);
     CHECK_EQUAL(1, sem.acquired_count);
 }

--- a/tests/semaphore_mock_test.cpp
+++ b/tests/semaphore_mock_test.cpp
@@ -46,10 +46,10 @@ TEST(SemaphoreMockTestGroup, CanTryTimeoutSemaphore)
     CHECK_EQUAL(1, sem.acquired_count);
 }
 
-TEST(SemaphoreMockTestGroup, CanReleaseSemaphore)
+TEST(SemaphoreMockTestGroup, CanSignalSemaphore)
 {
     os_semaphore_init(&sem, 1);
-    os_semaphore_release(&sem);
+    os_semaphore_signal(&sem);
 
     CHECK_EQUAL(2, sem.count);
 }

--- a/ucos-iii/semaphore.c
+++ b/ucos-iii/semaphore.c
@@ -62,13 +62,13 @@ bool os_semaphore_try_timeout(semaphore_t *sem, uint32_t timeout)
     }
 }
 
-void os_semaphore_release(semaphore_t *sem)
+void os_semaphore_signal(semaphore_t *sem)
 {
     OS_ERR err;
 
     OSSemPost(&sem->ucos_sem, OS_OPT_POST_1, &err);
 
     if (err != OS_ERR_NONE) {
-        PANIC("Semaphore release: %d", err);
+        PANIC("Semaphore signal: %d", err);
     }
 }

--- a/ucos-iii/semaphore.c
+++ b/ucos-iii/semaphore.c
@@ -14,14 +14,14 @@ void os_semaphore_init(semaphore_t *sem, uint32_t count)
     }
 }
 
-void os_semaphore_take(semaphore_t *sem)
+void os_semaphore_wait(semaphore_t *sem)
 {
     OS_ERR err;
 
     OSSemPend(&sem->ucos_sem, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
 
     if (err != OS_ERR_NONE) {
-        PANIC("Semaphore take: %d", err);
+        PANIC("Semaphore pend: %d", err);
     }
 }
 


### PR DESCRIPTION
Fixes #37. I have chosen `signal` and `wait` in the end. If anyone _really_ wants a different name, please open another PR.
